### PR TITLE
Pull request

### DIFF
--- a/ags/style.scss
+++ b/ags/style.scss
@@ -213,7 +213,7 @@ menu {
   }
 }
 
-.button-row {
+.button-row, .top-row {
   & > button {
     background: colors.$bg-secondary;
     margin: 0 1px;
@@ -223,7 +223,7 @@ menu {
     &:hover {
       background: colors.$bg-tertiary;
     }
-
+    
     &:first-child {
       border-top-left-radius: 10px;
       border-bottom-left-radius: 10px;
@@ -237,6 +237,24 @@ menu {
     }
   }
 }
+
+//Need some workouts///////////////
+switch {
+  padding: 4px;
+  border-radius: 16px;
+  background: functions.toRGB(color.adjust($color: wal.$color1, $lightness: -20%));
+  &:checked {
+    background: colors.$bg-tertiary;
+  }
+}
+
+switch slider {
+  border-radius: 12px;
+  color: colors.$bg-primary;
+  background: wal.$foreground;
+  transition: all 0.2s ease-in-out;
+}
+/////////////////////////////////////
 
 selection {
   background: colors.$bg-tertiary;

--- a/ags/style/_control-center.scss
+++ b/ags/style/_control-center.scss
@@ -31,7 +31,7 @@
       font-weight: 600;
     }
 
-    & > box:not(.button-row) icon {
+    & > box:not(.button-row):not(.top-row) icon {
       font-size: 12px;
       color: colors.$fg-disabled;
       margin-right: 3px;
@@ -43,7 +43,7 @@
       color: colors.$fg-disabled;
     }
 
-    & .button-row {
+    & .button-row, & .top-row {
       & button {
         padding: 7px;
         margin: {
@@ -165,6 +165,7 @@
 }
 
 box.history {
+  margin-top: 10px;
   background: colors.$bg-translucent;
   box-shadow: 0 0 6px 1px colors.$bg-translucent;
   border-radius: 24px;
@@ -182,8 +183,8 @@ box.history {
     }
   }
 
-  & > .button-row {
-    margin-top: 12px;
+  & > .button-row, & > .top-row {
+    margin-bottom: 12px;
 
     & button {
       padding: 6px;

--- a/ags/widget/bar/Media.ts
+++ b/ags/widget/bar/Media.ts
@@ -1,11 +1,13 @@
-import { bind } from "astal";
+import { bind, exec } from "astal";
 import { Gtk, Widget } from "astal/gtk3";
 import AstalMpris from "gi://AstalMpris";
 import { getSymbolicIcon } from "../../scripts/apps";
 import { Separator, SeparatorProps } from "../Separator";
 import { Windows } from "../../windows";
+import { Clipboard } from "../../scripts/clipboard";
 
 export function Media(): Gtk.Widget {
+    
     const connections: Array<number> = [];
 
     const mediaControlsRevealer: Widget.Revealer = new Widget.Revealer({
@@ -24,9 +26,14 @@ export function Media(): Gtk.Widget {
                             icon: "edit-paste-symbolic"
                         } as Widget.IconProps),
                         tooltipText: "Copy link to Clipboard",
-                        visible: bind(players[0], "metadata").as((metadata) => 
-                            metadata["xesam:url"]?.get_string()[0] != null),
-                        onClick: () => console.log(players[0].metadata["xesam:url"]?.get_string()[0]!)
+                        // AstalMpris.Player.metadata works only sometimes, so I'm not using it
+                        visible: bind(players[0], "metadata").as(Boolean),
+                        onClick: async () => {
+                            const link = exec(`playerctl --player=${
+                                players[0].busName.replace(/^org\.mpris\.MediaPlayer2\./i, "")
+                            } metadata xesam:url`);
+                            link && Clipboard.getDefault().copyAsync(link);
+                        }
                     } as Widget.ButtonProps),
                     new Widget.Button({
                         className: "previous",
@@ -97,17 +104,18 @@ export function Media(): Gtk.Widget {
                                 truncate: true
                             } as Widget.LabelProps),
                             Separator({
+                                visible: bind(players[0], "artist").as(artist => artist ? true : false),
                                 orientation: Gtk.Orientation.HORIZONTAL,
                                 size: 1,
                                 margin: 5,
-                                //cssColor: `rgb(180, 180, 180)`,
                                 alpha: .3
                             } as SeparatorProps),
                             new Widget.Label({
                                 className: "artist",
-                                label: bind(players[0], "artist").as((artist: string) => artist || "No Artist"),
+                                visible: bind(players[0], "artist").as(artist => artist ? true : false),
+                                label: bind(players[0], "artist").as((artist: string) => artist),
                                 maxWidthChars: 18,
-                                truncate: true
+                                truncate: true,
                             } as Widget.LabelProps)
                         ] : new Widget.Label({
                             label: "Crazy to think this widget haven't disappeared yet!"

--- a/ags/widget/bar/Status.ts
+++ b/ags/widget/bar/Status.ts
@@ -2,7 +2,7 @@ import AstalBluetooth from "gi://AstalBluetooth";
 import AstalNetwork from "gi://AstalNetwork";
 import AstalWp from "gi://AstalWp";
 
-import { bind, Binding, Variable } from "astal";
+import { bind, Binding, Variable, GLib } from "astal";
 import { Gtk, Widget } from "astal/gtk3";
 import { Wireplumber } from "../../scripts/volume";
 import { Notifications } from "../../scripts/notifications";
@@ -10,7 +10,9 @@ import { Windows } from "../../windows";
 import { Recording } from "../../scripts/recording";
 import { getDateTime } from "../../scripts/time";
 import { tr } from "../../i18n/intl";
+import { Time, timeout, idle } from "astal/time";
 
+import { IconStatus } from "../../scripts/icons";
 
 export function Status(): Gtk.Widget {
     const recordingTimer: Variable<string> = Variable.derive([
@@ -88,24 +90,64 @@ export function Status(): Gtk.Widget {
 function volumeStatus(props: { className?: string, endpoint: AstalWp.Endpoint, icon?: (string|Binding<string>) }): Gtk.Widget {
     return new Widget.EventBox({
         className: props.className,
-        onScroll: (_, event) => 
-            event.delta_y > 0 ?
+            onScroll: (_, event) => //ugh.....
+                event.delta_y > 0 ?
                 Wireplumber.getDefault().decreaseEndpointVolume(props.endpoint, 5)
             : Wireplumber.getDefault().increaseEndpointVolume(props.endpoint, 5),
-            child: new Widget.Box({
-                spacing: 2,
-                children: [
-                    new Widget.Icon({
-                        visible: props.icon,
-                        icon: props.icon,
-                    } as Widget.IconProps),
-                    new Widget.Label({
-                        className: "volume",
-                        label: bind(props.endpoint, "volume").as((volume: number) => 
-                            Math.floor(volume * 100) + "%")
-                    } as Widget.LabelProps),
-                ]
-            } as Widget.BoxProps)
+            setup: (eventbox) => {
+                let timer: (Time|undefined);
+                const connections: Array<number> = [];
+
+                const showRevealer = (self: any) => {
+                    self.revealChild = true;
+
+                    if (timer) {
+                        timer.cancel();
+                    }
+                                    
+                    timer = timeout(3000, () => {
+                        self.revealChild = false
+                        timer = undefined;
+                    });
+                }
+                
+                eventbox.add(new Widget.Box({
+                    spacing: 2,
+                    children: [
+                        new Widget.Icon({
+                            visible: props.icon,
+                            icon: props.icon,
+                        }),
+                        new Widget.Revealer({
+                            transitionDuration: 180,
+                            transitionType: Gtk.RevealerTransitionType.SLIDE_LEFT,
+                            setup: (self) => {
+                                
+                                connections.push(
+                                    eventbox.connect("hover", () => self.revealChild = true),
+                                    eventbox.connect("hover-lost", () => {
+                                        timeout(20, () => { //for smoothness (do not change it)
+                                            self.revealChild = false
+                                        })
+                                    }),
+                                    Wireplumber.getDefault().getDefaultSink().connect("notify::volume", () => {
+                                        showRevealer(self)
+                                    }),
+                                    Wireplumber.getDefault().getDefaultSource().connect("notify::volume", () => {
+                                        showRevealer(self)
+                                    }),
+                                )
+                            },
+                            onDestroy: () => connections.map(id => eventbox.disconnect(id)),
+                            child: new Widget.Label({
+                                className: "volume",
+                                label: bind(props.endpoint, "volume").as((volume: number) => 
+                                    Math.floor(volume * 100) + "%")
+                                } as Widget.LabelProps),
+                        } as Widget.RevealerProps)
+                    ]
+                } as Widget.BoxProps))
+            }
     } as Widget.EventBoxProps)
 }
 

--- a/ags/widget/center-window/BigMedia.ts
+++ b/ags/widget/center-window/BigMedia.ts
@@ -1,7 +1,7 @@
-import { AstalIO, bind, Binding, execAsync, GLib, timeout } from "astal";
+import { AstalIO, bind, Binding, exec, timeout } from "astal";
 import { Gtk, Widget } from "astal/gtk3";
 import AstalMpris from "gi://AstalMpris";
-
+import { Players } from "../../scripts/player";
 
 export function BigMedia(): Gtk.Widget {
     let dragTimer: (AstalIO.Time|undefined);
@@ -22,8 +22,8 @@ export function BigMedia(): Gtk.Widget {
                         hexpand: false,
                         orientation: Gtk.Orientation.VERTICAL,
                         marginTop: 6,
-                        visible: getAlbumArt(players[0]).as(Boolean),
-                        css: getAlbumArt(players[0]).as((artUrl: string|undefined) => 
+                        visible: Players.getDefault().getAlbumArt(players[0]).as(Boolean),
+                        css: Players.getDefault().getAlbumArt(players[0]).as((artUrl: string|undefined) => 
                             artUrl ? `.image { background-image: url('${artUrl}'); }` : undefined),
                         width_request: 132,
                         height_request: 128
@@ -60,7 +60,8 @@ export function BigMedia(): Gtk.Widget {
                             min: 0,
                             hexpand: true,
                             max: bind(players[0], "length").as((length: number) =>
-                                Math.floor(length)),
+                                (length > 129600000) ? Math.floor(players[0].get_position())
+                                    : Math.floor(length)), // for streams and players whitch dont have a length
                             value: bind(players[0], "position").as((position: number) =>
                                 Math.floor(position)),
                             onDragged: (slider: Widget.Slider) => {
@@ -101,9 +102,13 @@ export function BigMedia(): Gtk.Widget {
                                     icon: "edit-paste-symbolic"
                                 } as Widget.IconProps),
                                 tooltipText: "Copy link to Clipboard",
-                                visible: bind(players[0], "metadata").as((_meta: GLib.HashTable) =>
-                                    players[0].get_meta("xesam:url") === null),
-                                onClick: () => execAsync(`sh -c "wl-copy \\"$(playerctl metadata 'xesam:url')\\""`)
+                                visible: bind(players[0], "metadata").as(Boolean),
+                                onClick: async () => {
+                                    const link = exec(`playerctl --player=${
+                                        players[0].busName.replace(/^org\.mpris\.MediaPlayer2\./i, "")
+                                    } metadata xesam:url`);
+                                    link && Clipboard.getDefault().copyAsync(link);
+                                }
                             } as Widget.ButtonProps),
                             new Widget.Button({
                                 className: "shuffle",
@@ -189,7 +194,8 @@ export function BigMedia(): Gtk.Widget {
                         halign: Gtk.Align.END,
                         label: bind(players[0], "length").as((len/* bananananananana */: number) => {
                             const sec: number = Math.floor(len % 60);
-                            return (len > 0 && Number.isFinite(len)) ? 
+                            console.log(len);
+                            return (len > 0 && len < 129600000) ?
                                 `${Math.floor(len / 60)}:${sec < 10 ? "0" : ""}${sec}`
                             : "0:00";
                         })

--- a/ags/widget/control-center/NotifHistory.ts
+++ b/ags/widget/control-center/NotifHistory.ts
@@ -10,6 +10,46 @@ export const NotifHistory = () => {
         orientation: Gtk.Orientation.VERTICAL,
         className: bind(Notifications.getDefault(), "history").as(history => history.length > 0 ? "history" : "history hide"),
         children: [
+            new Widget.Box({
+                vexpand: false,
+                hexpand: true,
+                className: "top-row",
+                children: [
+                    new Widget.Box({
+                        className: "dnd-box",
+                        hexpand: true,
+                        halign: Gtk.Align.START,
+                        children: [
+                            new Widget.Label({
+                                css: "margin-right: 6px;",
+                                label: tr("control_center.tiles.dnd.title")
+                            } as Widget.LabelProps),
+                            new Widget.Switch({
+                                onNotifyActive: (self) => Notifications.getDefault().getNotifd().dontDisturb = self.active,
+                                state: Notifications.getDefault().getNotifd().dontDisturb,
+                            } as Widget.SwitchProps)
+                        ] 
+
+                    } as Widget.BoxProps),
+                    new Widget.Button({
+                        css: `border-radius: 10px;`,
+                        className: "clear-all",
+                        halign: Gtk.Align.END,
+                        child: new Widget.Box({
+                            children: [
+                                new Widget.Icon({
+                                    css: "margin-right: 6px;",
+                                    icon: "edit-clear-all-symbolic"
+                                } as Widget.IconProps),
+                                new Widget.Label({
+                                    label: tr("clear")
+                                } as Widget.LabelProps)
+                            ]
+                        } as Widget.BoxProps),
+                        onClick: () => Notifications.getDefault().clearHistory(),
+                    } as Widget.ButtonProps)
+                ]
+            }),
             new Widget.Scrollable({
                 className: "history",
                 hscroll: Gtk.PolicyType.NEVER,
@@ -36,30 +76,7 @@ export const NotifHistory = () => {
                             () => Notifications.getDefault().removeHistory(notification.id), true)
                     ))
                 } as Widget.BoxProps)
-            } as Widget.ScrollableProps),
-            new Widget.Box({
-                vexpand: false,
-                hexpand: true,
-                halign: Gtk.Align.END,
-                className: "button-row",
-                children: [
-                    new Widget.Button({
-                        className: "clear-all",
-                        child: new Widget.Box({
-                            children: [
-                                new Widget.Icon({
-                                    css: "margin-right: 6px;",
-                                    icon: "edit-clear-all-symbolic"
-                                } as Widget.IconProps),
-                                new Widget.Label({
-                                    label: tr("clear")
-                                } as Widget.LabelProps)
-                            ]
-                        } as Widget.BoxProps),
-                        onClick: () => Notifications.getDefault().clearHistory(),
-                    } as Widget.ButtonProps)
-                ]
-            })
+            } as Widget.ScrollableProps)
         ]
     } as Widget.BoxProps);
 }

--- a/ags/widget/control-center/pages/Network.ts
+++ b/ags/widget/control-center/pages/Network.ts
@@ -1,11 +1,20 @@
 import { Gtk, Widget } from "astal/gtk3";
 import { Page, PageButton } from "./Page";
 import AstalNetwork from "gi://AstalNetwork";
-import { bind } from "astal";
+import { bind, GLib } from "astal";
 import NM from "gi://NM";
+import NMA from "gi://NMA";
 import { Windows } from "../../../windows";
 import { tr } from "../../../i18n/intl";
 import { execApp } from "../../../scripts/apps";
+import { EntryPopup, EntryPopupProps } from "../../EntryPopup";
+import { Notifications } from "../../../scripts/notifications";
+import { AskPopup, AskPopupProps } from "../../AskPopup";
+import { encoder } from "../../../scripts/utils";
+import { setOSDMode } from "../../../window/OSD";
+
+const client = AstalNetwork.get_default().get_client();
+export const Network = AstalNetwork.get_default();
 
 export const PageNetwork: (() => Page) = () => new Page({
     id: "network",
@@ -17,10 +26,10 @@ export const PageNetwork: (() => Page) = () => new Page({
             image: new Widget.Icon({
                 icon: "arrow-circular-top-right-symbolic"
             } as Widget.IconProps),
-            visible: bind(AstalNetwork.get_default(), "primary").as((primary) => 
+            visible: bind(Network, "primary").as((primary) => 
                 primary === AstalNetwork.Primary.WIFI),
             tooltipText: "Re-scan connections",
-            onClick: () => AstalNetwork.get_default().wifi.scan()
+            onClick: () => Network.wifi.scan()
         } as Widget.ButtonProps)
     ],
     bottomButtons: [{
@@ -35,14 +44,13 @@ export const PageNetwork: (() => Page) = () => new Page({
             className: "devices",
             hexpand: true,
             orientation: Gtk.Orientation.VERTICAL,
-            visible: bind(AstalNetwork.get_default().get_client(), "devices").as((devs) => devs.length > 0),
-            children: bind(AstalNetwork.get_default().get_client(), "devices").as((devices) => {
+            visible: bind(Network.get_client(), "devices").as((devs) => devs.length > 0),
+            children: bind(Network.get_client(), "devices").as((devices) => {
                 devices = devices.filter(dev => dev.interface !== "lo");
 
                 return [
                     new Widget.Label({
                         label: tr("devices"),
-                        xalign: 0,
                         className: "sub-header",
                     } as Widget.LabelProps),
                     ...devices.filter(device => device.real).map(dev => PageButton({
@@ -53,6 +61,23 @@ export const PageNetwork: (() => Page) = () => new Page({
                                 : "network-wired-symbolic"),
                             title: bind(dev, "interface").as(iface => iface ?? 
                                 tr("control_center.pages.network.interface")),
+                            switches: [
+                                new Widget.Switch({
+                                    css: `margin: 2px 0px;
+                                        font-size: 18px;`,
+                                    onNotifyActive: (self) => {
+
+                                        const isDeviceActive = dev.state === NM.DeviceState.ACTIVATED
+
+                                        if (self.active === isDeviceActive) {
+                                            return;
+                                        }
+                                        
+                                        controlConnection(dev, self.active)
+                                    },
+                                    state: bind(dev, "state").as(state => state === NM.DeviceState.ACTIVATED ? true : false)
+                                } as Widget.SwitchProps) 
+                            ],
                             extraButtons: [
                                 new Widget.Button({
                                     image: new Widget.Icon({
@@ -72,35 +97,171 @@ export const PageNetwork: (() => Page) = () => new Page({
                 ]
             })
         } as Widget.BoxProps),
-        new Widget.Box({
-            className: "wireless-aps",
-            visible: bind(AstalNetwork.get_default(), "primary").as((primary) => primary === AstalNetwork.Primary.WIFI),
-            hexpand: true,
-            orientation: Gtk.Orientation.VERTICAL,
-            children: AstalNetwork.get_default().wifi ? bind(AstalNetwork.get_default().wifi.get_device(), "accessPoints").as((aps) =>
-                aps.map(ap => new Widget.Button({
-                    hexpand: true,
-                    onClick: () => console.log("connect to " + ap.get_ssid().toArray().toString()), // TODO I don't have a WiFi board :(
-                    child: new Widget.Box({
-                        hexpand: true,
-                        children: [
-                            new Widget.Icon({
-                                halign: Gtk.Align.START,
-                                className: "icon",
-                                icon: "network-wireless-signal-excellent-symbolic"
-                            } as Widget.IconProps),
-                            new Widget.Label({
-                                className: "ssid",
-                                halign: Gtk.Align.START,
-                                label: (getDecoded(ap.ssid.get_data()) ?? ap.ssid.get_data().toString()) ?? "Wi-Fi"
-                            } as Widget.LabelProps),
-                            new Widget.Label({
-                                className: "status",
-                            } as Widget.LabelProps)
+            new Widget.Box({
+                className: "wireless-aps",
+                visible: bind(Network, "primary").as((primary) => primary === AstalNetwork.Primary.WIFI),
+                hexpand: true,
+                orientation: Gtk.Orientation.VERTICAL,
+                children: Network.wifi ? bind(Network.wifi, "accessPoints").as((aps) => [
+                    new Widget.Label({
+                        className: "sub-header",
+                        label: "Wi-Fi"
+                        } as Widget.LabelProps),
+                            ...aps.filter(ap => ap.ssid).map(ap => {
+                                return PageButton({
+                                    title: bind(ap, "ssid").as(ssid => 
+                                        ssid ?? "Unknown SSID"),
+                                    icon: bind(ap, "iconName"),
+                                    endWidget: new Widget.Icon({
+                                    // @ts-ignore ts-for-gir generated the types wrong
+                                    icon: bind(ap, "flags").as(flags => flags & NM["80211ApFlags" as keyof typeof NM].PRIVACY ? 
+                                            "channel-secure-symbolic"
+                                        : "channel-insecure-symbolic"),
+                                    css: "font-size: 18px;"
+                                    } as Widget.IconProps),
+                                    extraButtons: [
+                                        new Widget.Button({
+                                            image: new Widget.Icon({
+                                                icon: "window-close-symbolic",
+                                                css: "font-size: 18px;"
+                                            } as Widget.IconProps)
+                                        } as Widget.ButtonProps)
+                                    ],
+                                    onClick: () => {
+
+                                        if (!ap.ssid) {
+                                            console.log("I dont see any of ssid...");
+                                            return;
+                                        }
+
+                                        const savedConnections = client.get_connections();
+                                        let existingWifiConnection: NM.RemoteConnection | null;
+
+                                        for (const conn of savedConnections) {
+                                            const wirelessSetting = conn.get_setting_wireless();
+
+                                            if (wirelessSetting && wirelessSetting.ssid && GLib.Bytes.new(encoder.encode(wirelessSetting.ssid)) === ap.ssid) {
+                                                console.log("Got ssid!");
+                                                existingWifiConnection = conn;
+                                                break;
+                                            }
+                                        }
+
+                                        if (existingWifiConnection) {
+                                            console.log("Connectiong by ssid...");
+                                            client.activate_connection_async(existingWifiConnection, Network.wifi.get_device(), ap.dbus_path, null, (_, asyncRes) => errorNotif(asyncRes, ""))
+                                        } else {
+                                            console.log("Well, creating a new connection...");
+                                            const uuid = NM.utils_uuid_generate();
+                                            const ssidBytes = GLib.Bytes.new(encoder.encode(ap.ssid));
+ 
+                                            const Bssid = ap.bssid;
+                                            
+                                            const connection = NM.SimpleConnection.new();
+                                            const connSetting = NM.SettingConnection.new();
+                                            const wifiSetting = NM.SettingWireless.new();
+                                            const wifiSecuritySetting = NM.SettingWirelessSecurity.new();
+                                            const setting8021x = NM.Setting8021x.new();
+                                                                                                                                                             
+                                            // @ts-ignore yep, type-gen issues again
+                                            if(ap.rsnFlags !& NM["80211ApSecurityFlags"].KEY_MGMT_802_1X &&
+                                            // @ts-ignore
+                                            ap.wpaFlags !& NM["80211ApSecurityFlags"].KEY_MGMT_802_1X) {
+                                                return;
+                                            }
+                                                                                                                                                       
+                                            connSetting.uuid = uuid;
+                                            connection.add_setting(connSetting);
+                                                                                                                                                             
+                                            connection.add_setting(wifiSetting);
+                                            wifiSetting.ssid = ssidBytes;
+                                            
+                                            wifiSecuritySetting.keyMgmt = "wpa-eap";
+                                            connection.add_setting(wifiSecuritySetting);
+                                                                                                                                       
+                                            setting8021x.add_eap_method("ttls");
+                                            setting8021x.phase2Auth = "mschapv2";
+                                            connection.add_setting(setting8021x);                                                                                          
+                                            const nmAP = Network.wifi.get_device().accessPoints.filter(nmAccessPoint => nmAccessPoint.ssid === ssidBytes)[0];
+                                            const dialog = NMA.WifiDialog.new(
+                                                Network.get_client(), connection, 
+                                                Network.wifi.get_device(), nmAP, 
+                                                false
+                                            );
+                        
+                                            dialog.show();
+                                        }
+                                    }
+                                });
+                            })
                         ]
-                    } as Widget.BoxProps)
-                } as Widget.ButtonProps))) : [],
-        } as Widget.BoxProps)
+                    ) : [],
+                } as Widget.BoxProps)
     ]
 });
+// For switches
+function controlConnection(device: (NM.Device|null), check: boolean): void {
+    
+    const activeConnection = device.get_active_connection() ?? null;
+    
+    if (check === true) {
+        const availableConnections = device.get_available_connections();
+        
+        if (availableConnections.length <= 0) {
+            return;
+        }
+        const connection = availableConnections[0];
+        client.activate_connection_async(connection, device, null, null, (_, asyncRes) => { 
+            try {
+                console.log(`Activation ${device.interface} was successful.`);
+            } catch (e) {
+                console.error(`Activation error: ${e.message}`);
+            }
+        });
+    } else {
+        client.deactivate_connection_async(activeConnection, null, (_, asyncRes) => {
+            try {
+                console.log(`Deactivation ${device.interface} was successful.`);
+            } catch (e) {
+                console.error(`Deactivation error: ${e.message}`);
+            }
+        })
+    }
+}
 
+function activateWirelessConnection(connection: NM.RemoteConnection, ssid: string): void {
+    Network.get_client().activate_connection_async(
+        connection, Network.wifi.get_device(), null, null, (_, asyncRes) => errorNotif(asyncRes, ssid));
+}
+
+function errorNotif(asyncRes: any, ssid: string = ""): void { //change notify for connected and errors scenario
+    const activeConnection = Network.get_client().activate_connection_finish(asyncRes);
+    if(!activeConnection) {
+        Notifications.getDefault().sendNotification({
+            appName: "network",
+            summary: "Couldn't activate wireless connection",
+            body: `An error occurred while activating the wireless connection "${ssid}"`
+        });
+        return;
+    }
+}
+
+function notifyConnectionError(ssid: string): void {
+    Notifications.getDefault().sendNotification({
+        appName: "network",
+        summary: "Coudn't connect Wi-Fi",
+        body: `An error occurred while trying to connect to the "${ssid}" access point. \nMaybe the password is invalid?`
+    });
+}
+function saveToDisk(remoteConnection: NM.RemoteConnection, ssid: string): void {
+    AskPopup({
+        text: `Save password for connection "${ssid}"?`,
+        acceptText: "Yes",
+        onAccept: () => remoteConnection.commit_changes_async(true, null, (_, asyncRes) => 
+            !remoteConnection.commit_changes_finish(asyncRes) && Notifications.getDefault().sendNotification({
+                appName: "network",
+                summary: "Couldn't save Wi-Fi password",
+                body: `An error occurred while trying to write the password for "${ssid}" to disk`
+        }))
+    } as AskPopupProps);
+}

--- a/ags/widget/control-center/pages/Page.ts
+++ b/ags/widget/control-center/pages/Page.ts
@@ -179,6 +179,7 @@ export function PageButton({ onDestroy, ...props }: {
     endWidget?: Gtk.Widget | Binding<Gtk.Widget>;
     description?: string | Binding<string>;
     extraButtons?: Array<Widget.Button> | Binding<Array<Gtk.Widget>>;
+    switches?: Array<Widget.Switch> | Binding<Array<Gtk.Widget>>;
     onDestroy?: (self: Widget.Box) => void;
     onClick?: (self: Widget.Button) => void;
     tooltipText?: string | Binding<string>;
@@ -213,7 +214,7 @@ export function PageButton({ onDestroy, ...props }: {
                                 new Widget.Label({
                                     className: "title",
                                     xalign: 0,
-                                    // truncating is not working, so I had to do this
+                                    //truncate: true,
                                     label: (props.title instanceof Binding) ? 
                                         props.title.as((title) => 
                                             `${title.substring(0, 35)}${
@@ -221,7 +222,6 @@ export function PageButton({ onDestroy, ...props }: {
                                     : `${props.title.substring(0, 35)}${
                                         props.title.length > 35 ? '…' : ""}`,
                                     tooltipText: props.title,
-                                    truncate: true,
                                 } as Widget.LabelProps),
                                 new Widget.Label({
                                     className: "description",
@@ -232,7 +232,7 @@ export function PageButton({ onDestroy, ...props }: {
                                     label: props.description,
                                     truncate: true,
                                     tooltipText: props.description
-                                } as Widget.LabelProps)
+                                } as Widget.LabelProps),
                             ]
                         } as Widget.BoxProps),
                         new Widget.Box({
@@ -240,11 +240,16 @@ export function PageButton({ onDestroy, ...props }: {
                                 props.endWidget.as(Boolean)
                             : props.endWidget,
                             halign: Gtk.Align.END,
-                            child: props.endWidget
+                            child: props.endWidget,
                         } as Widget.BoxProps)
                     ]
                 } as Widget.BoxProps)
             } as Widget.ButtonProps),
+             new Widget.Box({
+                //className: "switches",
+                visible: (props.switches instanceof Binding) ? props.switches.as(Boolean) : Boolean(props.switches),
+                children: props.switches
+            } as Widget.BoxProps),
             new Widget.Box({
                 className: "extra-buttons button-row",
                 visible: (props.extraButtons instanceof Binding) ? 

--- a/ags/widget/control-center/pages/Sound.ts
+++ b/ags/widget/control-center/pages/Sound.ts
@@ -1,9 +1,10 @@
 import { Page, PageButton, PageProps } from "./Page";
 import { bind, Variable } from "astal";
 import { Astal, Gtk, Widget } from "astal/gtk3";
-import { getAppIcon } from "../../../scripts/apps";
+import { getAppIcon, getSymbolicIcon } from "../../../scripts/apps";
 import { Wireplumber } from "../../../scripts/volume";
 import { tr } from "../../../i18n/intl";
+import { analyser } from "../../../scripts/utils";
 
 export function PageSound(): Page {
     const endpoints = Variable.derive([
@@ -26,7 +27,7 @@ export function PageSound(): Page {
                 PageButton({
                     className: bind(speaker, "isDefault").as(isDefault => isDefault ? "default" : ""),
                     icon: bind(speaker, "icon").as(icon => 
-                        Astal.Icon.lookup_icon(icon)? icon : "audio-card-symbolic"),
+                        getSymbolicIcon(icon) ?? "audio-card-symbolic"),
                     title: bind(speaker, "description").as(desc => desc ?? "Speaker"),
                     onClick: () => speaker.set_is_default(true),
                     endWidget: new Widget.Icon({
@@ -52,8 +53,8 @@ export function PageSound(): Page {
                                 orientation: Gtk.Orientation.HORIZONTAL,
                                 children: [
                                     new Widget.Icon({
-                                        icon: bind(stream, "name").as(name => 
-                                            getAppIcon(name.split(' ')[0]) ?? "application-x-executable-symbolic"),
+                                        icon: bind(stream, "description").as(icon =>
+                                            getSymbolicIcon(icon) ?? "application-x-executable-symbolic"),
                                         css: "font-size: 18px; margin-right: 6px;"
                                     } as Widget.IconProps),
                                     new Widget.Box({
@@ -69,7 +70,11 @@ export function PageSound(): Page {
                                                 ),
                                                 onDestroy: () => connections.map(id => eventbox.disconnect(id)),
                                                 child: new Widget.Label({
-                                                    label: bind(stream, "name").as(name => name || "Unknown"),
+                                                    label: bind(stream, "description").as(desc => { //need to add filter for "audio stream1", ""
+                                                        const maxLength = (35 - (desc.length + 3));
+                                                        let title = `${stream.name.substring(0, maxLength)}${stream.name.length >= maxLength ? '...' : ""}`
+                                                        return `${desc} - ${title}`;
+                                                        }),
                                                     truncate: true,
                                                     tooltipText: bind(stream, "name"),
                                                     className: "name",

--- a/ags/widget/control-center/pages/Sound.ts
+++ b/ags/widget/control-center/pages/Sound.ts
@@ -70,7 +70,7 @@ export function PageSound(): Page {
                                                 ),
                                                 onDestroy: () => connections.map(id => eventbox.disconnect(id)),
                                                 child: new Widget.Label({
-                                                    label: bind(stream, "description").as(desc => { //need to add filter for "audio stream1", ""
+                                                    label: bind(stream, "description").as(desc => { //need to add filter for "audio stream1" and etc...
                                                         const maxLength = (35 - (desc.length + 3));
                                                         let title = `${stream.name.substring(0, maxLength)}${stream.name.length >= maxLength ? '...' : ""}`
                                                         return `${desc} - ${title}`;

--- a/ags/window/OSD.ts
+++ b/ags/window/OSD.ts
@@ -1,14 +1,15 @@
 import { bind, Binding, Variable } from "astal";
 import { Astal, Gtk, Widget } from "astal/gtk3";
 import { Wireplumber } from "../scripts/volume";
+import AstalWp from "gi://AstalWp";
 
 export enum OSDModes {
     SINK,
+    SOURCE,
     BRIGHTNESS
 }
 
 let osdMode: (Variable<OSDModes>|null);
-let osdIcon: (Binding<string | undefined>|null);
 
 export function setOSDMode(newMode: OSDModes): void {
     if(!osdMode) return;
@@ -16,18 +17,101 @@ export function setOSDMode(newMode: OSDModes): void {
     osdMode.set(newMode);
 }
 
+function createOSD(
+    props: Widget.BoxProps,
+    bindable: AstalWp.Endpoint,
+    iconName: string | Binding<string>,
+    labelOSD: string | Binding<string>,
+    valueOSD: number | Binding<number>,
+    maxValueOSD: number | Binding<number>
+
+) {
+    return new Widget.Box({
+        ...props,
+        className: `osd ${props.className || ''}`, 
+        expand: true,
+        children: [
+            new Widget.Icon({
+                className: "icon",
+                icon: iconName,
+            } as Widget.IconProps),
+            new Widget.Box({
+                className: "volume",
+                orientation: Gtk.Orientation.VERTICAL,
+                valign: Gtk.Align.CENTER,
+                children: [
+                    new Widget.Label({
+                        className: "device",
+                        label: labelOSD,
+                        truncate: true,
+                    } as Widget.LabelProps),
+                    new Widget.Box({
+                        vexpand: false,
+                        expand: false,
+                        children: [
+                            new Widget.LevelBar({
+                                className: "levelbar",
+                                width_request: 120,
+                                value: valueOSD,
+                                maxValue: maxValueOSD,
+                                expand: true,
+                            } as Widget.LevelBarProps),
+                            /*new Widget.Label({
+                                className: "value",
+                                label: bind(Wireplumber.getDefault().getDefaultSink(), "volume").as((volume: number) => 
+                                    `${Math.floor(volume * 100)}%`),
+                                vexpand: false,
+                                expand: false,
+                                halign: Gtk.Align.CENTER
+                            } as Widget.LabelProps)*/
+                        ]
+                    } as Widget.BoxProps)
+                ]
+            } as Widget.BoxProps)
+        ]
+    } as Widget.BoxProps)
+}
+
+function OSDSink() {
+    const audio = Wireplumber.getDefault().getDefaultSink();
+    return createOSD(
+        { name: "sink" },
+        audio,
+        bind(audio, "volumeIcon").as(icon => 
+            !Wireplumber.getDefault().isMutedSink() && Wireplumber.getDefault().getSinkVolume() > 0 ? 
+                icon : "audio-volume-muted-symbolic"),
+        bind(audio, "description").as((description: string) => 
+            description || "Speaker"),
+        bind(audio, "volume").as((volume: number) => 
+            Math.floor(volume * 100)),
+        bind(Wireplumber.getWireplumber(), "defaultSpeaker").as(() => 
+            Wireplumber.getDefault().getMaxSinkVolume())
+    )
+}
+
+function OSDSource() {
+    const source = Wireplumber.getDefault().getDefaultSource();
+    return createOSD(
+        { name: "source" },
+        source,
+        bind(source, "volumeIcon").as(icon => 
+            !Wireplumber.getDefault().isMutedSource() && Wireplumber.getDefault().getSourceVolume() > 0 ? 
+                icon : "microphone-sensitivity-muted-symbolic"),
+        bind(source, "description").as((description: string) => 
+            description || "Microphone"),
+        bind(source, "volume").as((volume: number) => 
+            Math.floor(volume * 100)),
+        bind(Wireplumber.getWireplumber(), "defaultMicrophone").as(() =>
+            Wireplumber.getDefault().getMaxSourceVolume())
+    )
+}
+
 export const OSD = (mon: number) => {
     osdMode = new Variable<OSDModes>(OSDModes.SINK);
-    osdIcon = osdMode().as((mode: OSDModes) => {
-        switch(mode) {
-            case OSDModes.SINK: return "󰕾";
-            case OSDModes.BRIGHTNESS: return "󰃠";
-            default: return "󱧣";
-        }
-    });
 
     return new Widget.Window({
         namespace: "osd",
+        className: "osd-window",
         layer: Astal.Layer.OVERLAY,
         anchor: Astal.WindowAnchor.BOTTOM,
         canFocus: false,
@@ -39,54 +123,21 @@ export const OSD = (mon: number) => {
             osdMode?.drop();
 
             osdMode = null;
-            osdIcon = null;
         },
-        child: new Widget.Box({
-            className: "osd",
+        child: new Widget.Stack({
+            visibleChildName: bind(osdMode, "value").as((mode: OSDModes) => {
+                switch (mode) {
+                    case OSDModes.SINK: return "sink";
+                    case OSDModes.SOURCE: return "source";
+                    default: return "sink";
+                }
+            }),
+            onDestroy: () => {
+                osdMode = null
+            },
             children: [
-                new Widget.Icon({
-                    className: "icon",
-                    icon: bind(Wireplumber.getDefault().getDefaultSink(), "volumeIcon").as(icon => 
-                        !Wireplumber.getDefault().isMutedSink() && Wireplumber.getDefault().getSinkVolume() > 0 ? icon : "audio-volume-muted-symbolic"),
-                } as Widget.IconProps),
-                new Widget.Box({
-                    className: "volume",
-                    orientation: Gtk.Orientation.VERTICAL,
-                    valign: Gtk.Align.CENTER,
-                    children: [
-                        new Widget.Label({
-                            className: "device",
-                            label: bind(Wireplumber.getDefault().getDefaultSink(), "name").as((name: string) => 
-                                name || "Speaker"),
-                            halign: Gtk.Align.CENTER
-                        } as Widget.LabelProps),
-                        new Widget.Box({
-                            vexpand: false,
-                            expand: false,
-                            children: [
-                                new Widget.LevelBar({
-                                    className: "levelbar",
-                                    width_request: 120,
-                                    value: bind(Wireplumber.getDefault().getDefaultSink(), "volume").as((volume: number) => 
-                                        Math.floor(volume * 100)),
-                                    maxValue: bind(Wireplumber.getWireplumber(), "defaultSpeaker").as(() =>
-                                        Wireplumber.getDefault().getMaxSinkVolume()),
-                                    vexpand: false,
-                                    expand: false,
-                                    halign: Gtk.Align.CENTER
-                                } as Widget.LevelBarProps),
-                                /*new Widget.Label({
-                                    className: "value",
-                                    label: bind(Wireplumber.getDefault().getDefaultSink(), "volume").as((volume: number) => 
-                                        `${Math.floor(volume * 100)}%`),
-                                    vexpand: false,
-                                    expand: false,
-                                    halign: Gtk.Align.CENTER
-                                } as Widget.LabelProps)*/
-                            ]
-                        } as Widget.BoxProps)
-                    ]
-                } as Widget.BoxProps)
+                OSDSink(),
+                OSDSource(),
             ]
         } as Widget.BoxProps)
     } as Widget.WindowProps);


### PR DESCRIPTION
Add switchers in `Network.ts`, `NotiHistory.ts`:

- Interfaces and DND mode can be quickly switched on and off.

<details>

<summary>
Switchers
</summary>

Notifications DND:
![image](https://github.com/user-attachments/assets/70c14f50-38de-4a13-a97a-e0698bbc4359)

Network Page:
![image](https://github.com/user-attachments/assets/d2b36cfd-10ea-474e-ae68-19721374f4b2)


</details>

Change `OSD.ts`:

- OSD can now display not only audio volume, but also microphone sensitivity. You can also further integrate the screen brightness indicator, change the keyboard layout (turning on CAPS Lock, Num Lock, etc.)

Add revealers in `status.ts`:

- Compactly displays the current volume of the device.

<details>

<summary>
OSD & Revealers
</summary>

[Replay_2025-06-28_22-01-14.webm](https://github.com/user-attachments/assets/c4fc8ba7-a112-440c-9234-5b10110d6af8)


</details>

Change `media.ts` labels: 

- Now, if the player does not have data about the artist, it will not show it (for example, streams, videos, etc.).

<details>

<summary>
Media
</summary>

![image](https://github.com/user-attachments/assets/02e6f717-ff88-4fb5-8667-c6110518c55a)

</details>


Change `Sound.ts` page: 

- Displays the icons correctly and shows not only the names of the streams, but also their descriptions.

<details>

<summary>
Sound
</summary>

![image](https://github.com/user-attachments/assets/49f95e0f-af86-4ab2-babe-d2afe5c78d64)


</details>


_I might have forgotten to add or change something._